### PR TITLE
Update to work with chromedriver >= 2.39, build script fix for Windows

### DIFF
--- a/lib/devtools.js
+++ b/lib/devtools.js
@@ -50,6 +50,7 @@ export default class DevToolsService {
             await browser.url('chrome://version')
             return browser.getText('#command_line').then((args) => parseInt(args.match(/--remote-debugging-port=(\d*)/)[1]))
         } catch (err) {
+            console.log(err)
             console.log(`Could'nt connect to chrome`)
         }
     }

--- a/lib/devtools.js
+++ b/lib/devtools.js
@@ -1,4 +1,6 @@
 import CDP from 'chrome-remote-interface'
+const fs = require('fs')
+const path = require('path')
 
 export default class DevToolsService {
     beforeSession (_, caps) {
@@ -48,7 +50,33 @@ export default class DevToolsService {
     async _findChromePort () {
         try {
             await browser.url('chrome://version')
-            return browser.getText('#command_line').then((args) => parseInt(args.match(/--remote-debugging-port=(\d*)/)[1]))
+
+            let chromeCommandLine = await browser.getText('#command_line')
+            let indexOfUDD = chromeCommandLine.indexOf('--user-data-dir=') + 16
+            let chromeUserDir = chromeCommandLine.substring(
+                indexOfUDD,
+                chromeCommandLine.indexOf(' --', indexOfUDD)
+            ).replace(/^"(.*)"$/imu, '$1') //** * trim quotes for Windows */
+
+            let devToolsFilePath = path.join(chromeUserDir, '/DevToolsActivePort')
+
+            let isDevToolsFileExist = fs.existsSync(devToolsFilePath)
+            if (isDevToolsFileExist == false) {
+                /**
+                * deprecated method for old chromedriver 
+                * https://chromium-review.googlesource.com/c/chromium/src/+/994378
+                */
+                return browser.getText('#command_line').then((args) => parseInt(args.match(/--remote-debugging-port=(\d*)/)[1]))
+            } else {
+                /**
+                * new method for chromedriver >= 2.39
+                */
+                let devToolsFile = fs.readFileSync(devToolsFilePath, 'utf8')
+                let debugPort = devToolsFile.match(/(\d*)/)
+                return parseInt(debugPort)
+            }
+
+            throw new Error(`Can't extract debug port`)
         } catch (err) {
             console.log(err)
             console.log(`Could'nt connect to chrome`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -6639,7 +6639,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "run-async": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "build": "run-s clean compile",
     "ci": "run-s test",
-    "clean": "rm -rf ./build ./coverage",
+    "clean": "rimraf ./build ./coverage",
     "compile": "babel lib -d build --source-maps inline",
     "eslint": "eslint ./lib ./test ./*.js",
     "release": "run-s release:patch",
@@ -54,6 +54,7 @@
     "jest": "^21.2.1",
     "np": "^2.16.0",
     "npm-run-all": "^4.1.2",
+    "rimraf": "^2.6.2",
     "shelljs": "^0.7.8"
   },
   "jest": {


### PR DESCRIPTION
Tested both on macOS and Windows 7.

By the way - chrome://vesrion is empty in headless mode. So still need to find a better way.