### PR TITLE
Fix issue #13. Changed the way of finding chrome remote-debugger-port

### DIFF
--- a/lib/devtools.js
+++ b/lib/devtools.js
@@ -2,8 +2,8 @@ import CDP from 'chrome-remote-interface'
 
 export default class DevToolsService {
     beforeSession (_, caps) {
-        if (caps.browserName !== 'chrome' || (caps.version && caps.version < 63)) {
-            console.error('The wdio-devtools-service currently only supports Chrome version 63 and up')
+        if (caps.browserName !== 'chrome' || (caps.version && caps.version < 67)) {
+            console.error('The wdio-devtools-service currently only supports Chrome version 67 and up')
         }
     }
 
@@ -47,10 +47,9 @@ export default class DevToolsService {
 
     async _findChromePort () {
         try {
-            await browser.url('chrome://version')
-            return browser.getText('#command_line').then((args) => parseInt(args.match(/--remote-debugging-port=(\d*)/)[1]))
+            return browser.session().value['goog:chromeOptions'].debuggerAddress.split(":")[1];
         } catch (err) {
-            console.log(`Could'nt connect to chrome`)
+            console.log(`Couldn't get chrome remote-debugger-port`)
         }
     }
 


### PR DESCRIPTION
Please let me know what you think. It might be a good idea to try both ways of getting the port so it is compatible with more chromedriver versions.