### PR TITLE
Fix: Return remote debugging port if found in `chrome://version`

### DIFF
--- a/lib/devtools.js
+++ b/lib/devtools.js
@@ -63,8 +63,9 @@ export default class DevToolsService {
                 const userDataDir = cmdLineText.match(RE_USER_DATA_DIR_SWITCH)[1].trim()
                 const devToolsActivePortFile = fs.readFileSync(path.join(userDataDir, 'DevToolsActivePort'), 'utf8')
                 port = parseInt(devToolsActivePortFile.split('\n').shift(), 10)
-                return port
             }
+
+            return port
         } catch (err) {
             console.log(`Could not connect to chrome`)
         }


### PR DESCRIPTION
We want to return the `--remote-debugging-port` if we find it in `chrome://version` in order to avoid errors such as `(node:17001) UnhandledPromiseRejectionWarning: Error: connect ECONNREFUSED 127.0.0.1:9222`